### PR TITLE
COMP: Fix missing/renamed icons in extension install package

### DIFF
--- a/BoneReconstructionPlanner/CMakeLists.txt
+++ b/BoneReconstructionPlanner/CMakeLists.txt
@@ -9,8 +9,11 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
-  Resources/Icons/iconFibulaCropped.png
-  Resources/Icons/iconResectedMandible.png
+  Resources/Icons/iconCTFibula.png
+  Resources/Icons/iconCTFibulaCropped.png
+  Resources/Icons/iconCTMandible.png
+  Resources/Icons/iconFibulaSegmentation.png
+  Resources/Icons/iconMandibleSegmentation.png
   Resources/UI/${MODULE_NAME}.ui
   )
 


### PR DESCRIPTION
This aims to address configuration errors as observed in https://slicer.cdash.org/build/2869672/configure.

Some new icons were added in https://github.com/SlicerIGT/SlicerBoneReconstructionPlanner/commit/29bf7255f8593f17e27b6f5ae48bd0418f53260b, but were not included the extension install package.

An issue with some renamed icons was introduced in https://github.com/SlicerIGT/SlicerBoneReconstructionPlanner/commit/a81ed86000ffa40eeb0e1a14c25b032fb53e40a8.

cc: @mauigna06 for review